### PR TITLE
Fix IOS "UIReturnKeyType" Error

### DIFF
--- a/mobile/src/stateMachine/views/checkin/recordTextCheckIn.tsx
+++ b/mobile/src/stateMachine/views/checkin/recordTextCheckIn.tsx
@@ -185,7 +185,7 @@ export class TextRecordView extends CheckInViewBase {
                                         model={textRecord}
                                         multiline
                                         styleError={styles.error}
-                                        returnKeyType="none"
+                                        returnKeyType="default"
                                         skipBlurOnSubmit
                                     />
                                     <Button


### PR DESCRIPTION
PR to fix the "UIReturnKeyType" error that was previously being triggered when you check-in on IOS, and choose to respond to a prompt with the "Write" option. The error was happening when you click the "Write" button (screenshot below). 

Steps to test:
1. Pull in the change on this PR to your instance of the project.
2. Login on IOS and begin a check-in. Follow the prompts until you get to the screen below.
2. Click the circled button. If no error appear, it is working.

<img src="https://user-images.githubusercontent.com/47067364/103385095-e400fe00-4aad-11eb-8080-74d762306d28.png" width="300" height="592.5">