### PR TITLE
Fix "Record" button bug on IOS and Android

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.companionkit">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
       android:name=".MainApplication"

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -44,7 +44,7 @@
     ],
     "googleServicesFile": "./configs/app/GoogleService-Info.plist",
     "infoPlist": {
-      "NSMicrophoneUsageDescription": "...",
+      "NSMicrophoneUsageDescription": "Enable Bipolar Bridges to record your response to this check-in prompt.",
       "NSPhotoLibraryUsageDescription": "..."
     }
   },

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -44,7 +44,7 @@
     ],
     "googleServicesFile": "./configs/app/GoogleService-Info.plist",
     "infoPlist": {
-      "NSMicrophoneUsageDescription": "Enable Bipolar Bridges to record your response to this check-in prompt.",
+      "NSMicrophoneUsageDescription": "Enable this app to record your response to this check-in prompt.",
       "NSPhotoLibraryUsageDescription": "..."
     }
   },

--- a/mobile/ios/CompanionKit/Info.plist
+++ b/mobile/ios/CompanionKit/Info.plist
@@ -39,6 +39,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Enable Bipolar Bridges to record your response to this check-in prompt.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/mobile/ios/CompanionKit/Info.plist
+++ b/mobile/ios/CompanionKit/Info.plist
@@ -40,7 +40,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Enable Bipolar Bridges to record your response to this check-in prompt.</string>
+	<string>Enable this app to record your response to this check-in prompt.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Bug: 
- On Android, it never prompts the user to enable microphone permissions so it always comes back as "denied" and you cannot record
- On IOS, it crashes the app
