### PR TITLE
Script to set up new project clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Clone the respository and ensure you have the requirements below:
 
 ### 2. Configure the Development Environment
 
+If you are setting up the project for the first time, follow the steps below. Otherwise, you may want to check out the instructions in the following section.
+
 1. Download the `GoogleService-Info.plist` file from the ios app on firebase. Place this file in `./mobile/configs/app`.
 2. Download the `google-services.json` file from the android app on firebase. Place this file in `./mobile/configs/app` and in `./mobile/android/app`.
 3. Copy the `.env-starter` file to `.env` in the root directory, and fill in each variable with the correct values. Alternatively, obtain an environment file from another developer on the team.
@@ -42,6 +44,14 @@ Clone the respository and ensure you have the requirements below:
 	(we will fill in the path in the next step)
 
 6. Go to the Google Cloud Platform [here](https://console.cloud.google.com/iam-admin/serviceaccounts?project=bipolarbridges). On the "App Engine default service account", click the three dots, select "Create key", and download the json file. Fill in the path to this downloaded file in the `.env` from the previous step.
+
+### 3. (Optional) Importing Environment from an Existing Project Instance
+
+If you have an already set-up clone of the project on your machine, and wish to copy the configuration over to a fresh clone - sometimes useful in cases of failed setup, broken dependencies etc.- you can run the provided script to automate the process, e.g.
+
+```sh
+bash bin/migrate-project.bash <path-to-old-project> <path-to-new-project>
+```
 
 ## Running and Deploying the App
 

--- a/bin/migrate-project.bash
+++ b/bin/migrate-project.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Helps migrate from an existing companion app setup to a fresh clone.
+# Essentially replaces step 2 of the README (Configure Development Environment)
+# Provided that the existing project is configured correctly.
+
+old=$1
+new=$2
+
+if [[ -z "$old" ]]; then
+	echo "must provide path to old project" && exit 1
+fi
+
+if [[ -z "$new" ]]; then
+	new="."
+fi
+
+__check_confirm__() {
+	if [[ ! $confirm =~ ^[Yy]$ ]]; then
+		echo "exiting" && exit 0
+	fi
+} 
+
+__fail__() {
+	echo "migration failed. There may be leftover files" && exit 1 
+}
+
+read -r -p "Will copy files from $old - Continue? [Y/n] " confirm
+__check_confirm__
+
+cp "$old/mobile/configs/app/google-services.json" "$new/mobile/configs/app/google-services.json" || __fail__
+cp "$old/mobile/configs/app/GoogleService-Info.plist" "$new/mobile/configs/app/GoogleService-Info.plist" || __fail__
+cp "$new/mobile/configs/app/google-services.json" "$new/mobile/android/app" || __fail__
+cp "$old/.env" "$new/.env" || __fail__
+cp "$old/server/functions/.env" "$new/server/functions/.env" || __fail__
+
+echo "done copying."
+
+read -r -p "Run setup? [Y/n] " confirm
+__check_confirm__
+
+cd "$new" && bash bin/setup.bash

--- a/bin/migrate-project.bash
+++ b/bin/migrate-project.bash
@@ -25,14 +25,23 @@ __fail__() {
 	echo "migration failed. There may be leftover files" && exit 1 
 }
 
-read -r -p "Will copy files from $old - Continue? [Y/n] " confirm
+read -r -p "Will copy files from $old to $new - Continue? (You will be able to choose files to copy) [Y/n] " confirm
 __check_confirm__
 
-cp "$old/mobile/configs/app/google-services.json" "$new/mobile/configs/app/google-services.json" || __fail__
-cp "$old/mobile/configs/app/GoogleService-Info.plist" "$new/mobile/configs/app/GoogleService-Info.plist" || __fail__
-cp "$new/mobile/configs/app/google-services.json" "$new/mobile/android/app" || __fail__
-cp "$old/.env" "$new/.env" || __fail__
-cp "$old/server/functions/.env" "$new/server/functions/.env" || __fail__
+__copy__() {
+	read -r -p "Copy $1 ? [Y/n]" confirm
+	if [[ ! $confirm =~ ^[Yy] ]]; then
+		echo "skipping"
+	else
+		cp "$old/$1" "$new/$1" || __fail__
+	fi
+}
+
+__copy__ "mobile/configs/app/google-services.json"
+__copy__ "mobile/configs/app/GoogleService-Info.plist"
+__copy__ "mobile/android/app/google-services.json"
+__copy__ ".env"
+__copy__ "server/functions/.env"
 
 echo "done copying."
 

--- a/bin/migrate-project.bash
+++ b/bin/migrate-project.bash
@@ -6,7 +6,11 @@
 
 # Usage
 
-# ./bin/migrate-project.bash old_dir new_dir
+# bash bin/migrate-project.bash <old_dir> <new_dir>
+
+# OR
+# ./bin/migrate-project.bash <old_dir> <new_dir>
+
 
 old=$1
 new=$2


### PR DESCRIPTION
## Changes
Adds a bash script that can be used to copy config files from one instance of the project to another.

## Requirements
If you could run the original setup bash script, you should be able to run this.

## PR Dependencies
Depends on: None

## Merged Branches and Other Dependencies
Merged branch(es): None
Other dependencies: None

## Preview
N/A

## Testing
Manual: Read through the script then try running it.
