### PR TITLE
[Qol Survey] Improve qol survey saving implementation

### DIFF
--- a/common/controllers/QoLController.ts
+++ b/common/controllers/QoLController.ts
@@ -28,7 +28,7 @@ export default class QoLControllerBase implements IQoLController {
         return await RepoFactory.Instance.surveyResults.getAllResults(this._userId);
     }
 
-    // Submit new survey results
+    // Submit new survey results (after survey is finished)
     public async sendSurveyResults(results: QolSurveyResults, aggregateScore: number, surveyType: QolSurveyType, startDate: number, questionCompletionDates: number[]): Promise<boolean> {
         logger.log(`add qol results: userId = ${this._userId}`);
         let userState: UserState = await RepoFactory.Instance.userState.getByUserId(this._userId);
@@ -36,8 +36,7 @@ export default class QoLControllerBase implements IQoLController {
         return true;
     }
 
-    // Store partial survey state
-    // Any subsequent calls to get will return this state
+    // Send state of survey while it is in progress (partialy finsished)
     public async sendPartialQol(qol: PartialQol): Promise<boolean> {
 
         logger.log(`set partial qol: userId = ${this._userId}`);
@@ -49,7 +48,7 @@ export default class QoLControllerBase implements IQoLController {
             if (st) {
                 st.surveyState = qol;
             } else {
-                // This is the inital setup of the user's UserState and it is set after the very first (onboarding) qol survey
+                // This is the inital setup of the user's UserState and it is set after the first question of the onboarding qol survey
                 st = {
                     surveyState: qol,
                     focusedDomains: { domains: [], subdomains: [] },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -60,7 +60,8 @@
     "react-native-vector-icons": "^8.1.0",
     "react-native-video": "^5.2.0",
     "simplex-noise": "3.0.0",
-    "three": "^0.125.0"
+    "three": "^0.125.0",
+    "tiny-timer": "^1.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/mobile/src/stateMachine/views/qol/qolQuestion.tsx
+++ b/mobile/src/stateMachine/views/qol/qolQuestion.tsx
@@ -37,13 +37,13 @@ export class QolQuestion extends ViewState {
 
     // Called when survey is completed
     private finish = async () => {
-        this.trigger(ScenarioTriggers.Submit);
         await this.viewModel.sendSurveyResults();
 
         if (this.viewModel.isUnfinished) {
-            await this.viewModel.saveSurveyProgress(null);
+            await this.viewModel.saveSurveyProgress(true);
         }
-        this.viewModel.updatePendingQol();
+        this.viewModel.resolvePendingQol();
+        this.trigger(ScenarioTriggers.Submit);
     }
 
     private isNextDomain = (currQuestion: number) => {
@@ -69,8 +69,8 @@ export class QolQuestion extends ViewState {
         });
     }
 
-    private nextQuestion = (prevResponse: number) => {
-        this.viewModel.savePrevResponse(prevResponse);
+    private nextQuestion = async (prevResponse: number) => {
+        await this.viewModel.savePrevResponse(prevResponse);
         const newDomainMag: number = this.calculateNewDomainMag(prevResponse);
         this.persona.qolArmMagnitudes = { ...this.persona.qolArmMagnitudes, [this.viewModel.domain]: newDomainMag };
 

--- a/mobile/src/stateMachine/views/qol/qolQuestion.tsx
+++ b/mobile/src/stateMachine/views/qol/qolQuestion.tsx
@@ -32,6 +32,7 @@ export class QolQuestion extends ViewState {
 
     private cancel = () => {
         this.persona.qolArmMagnitudes = this.viewModel.originalArmMagnitudes;
+        this.viewModel.willExitSurvey();
         this.trigger(ScenarioTriggers.Cancel);
     }
 

--- a/mobile/src/stateMachine/views/qol/startQOL.tsx
+++ b/mobile/src/stateMachine/views/qol/startQOL.tsx
@@ -27,7 +27,7 @@ export class QolStartView extends ViewState {
             await this.viewModel.sendSurveyResults();
 
             if (this.viewModel.isUnfinished) {
-                await this.viewModel.saveSurveyProgress(null);
+                await this.viewModel.saveSurveyProgress(true);
             }
             this.viewModel.qolSurveyType = QolSurveyType.Full;
         }
@@ -37,8 +37,9 @@ export class QolStartView extends ViewState {
         return AppViewModel.Instance.QOL;
     }
 
-    private saveProgress = async () => {
-        await this.viewModel.saveSurveyProgress(PersonaArmState.createZeroArmState());
+    private exitSurvey = async () => {
+        await this.viewModel.saveSurveyProgress(true);
+        this.viewModel.qolArmMagnitudes = PersonaArmState.createZeroArmState();
         this.cancel();
     }
     private cancel = () => {
@@ -54,7 +55,7 @@ export class QolStartView extends ViewState {
             title: `Are you sure you want to pause the survey?`,
             primaryButton: {
                 text: 'yes',
-                action: this.saveProgress,
+                action: this.exitSurvey,
             },
             secondaryButton: {
                 text: 'no, go back',

--- a/mobile/src/stateMachine/views/qol/startQOL.tsx
+++ b/mobile/src/stateMachine/views/qol/startQOL.tsx
@@ -40,9 +40,6 @@ export class QolStartView extends ViewState {
     private exitSurvey = async () => {
         await this.viewModel.saveSurveyProgress(true);
         this.viewModel.qolArmMagnitudes = PersonaArmState.createZeroArmState();
-        this.cancel();
-    }
-    private cancel = () => {
         this.trigger(ScenarioTriggers.Cancel);
     }
 

--- a/mobile/src/viewModels/QoLViewModel.ts
+++ b/mobile/src/viewModels/QoLViewModel.ts
@@ -116,7 +116,7 @@ export default class QOLSurveyViewModel {
         }
     }
 
-    private submissionTimer = null;
+    private submissionTimer: Timer = null;
 
     private timerFired(self: QOLSurveyViewModel) {
         const responses = this.surveyResponses;
@@ -124,6 +124,13 @@ export default class QOLSurveyViewModel {
             self.sentResponses = responses;
             self.saveSurveyProgress()
         }
+    }
+
+    // Call this when exiting the qol survey part way through
+    public willExitSurvey() {
+        this.submissionTimer.stop();
+        this.submissionTimer = null;
+        this.timerFired(this);
     }
 
     public async savePrevResponse(prevResponse: number) {

--- a/mobile/src/viewModels/QoLViewModel.ts
+++ b/mobile/src/viewModels/QoLViewModel.ts
@@ -29,8 +29,6 @@ export default class QOLSurveyViewModel {
     private readonly _settings: ILocalSettingsController = AppController.Instance.User.localSettings;
 
     constructor() {
-        this.submissionTimer.on('tick', () => this.timerFired(this));
-
         this.initModel = AppController.Instance.User.qol.getPartialQol().then((partialQolState: PartialQol) => {
             if (partialQolState !== null && typeof (partialQolState) !== 'undefined') {
                 this._questionNum = partialQolState.questionNum;
@@ -151,6 +149,7 @@ export default class QOLSurveyViewModel {
             await this.saveSurveyProgress();
         } else if (this.submissionTimer == null || this.submissionTimer.status != 'running') {
             this.submissionTimer = new Timer({ interval: 5000 });
+            this.submissionTimer.on('tick', () => this.timerFired(this));
             this.submissionTimer.start(60000 * 1000); // max out at 1000 min
         }
     }

--- a/mobile/src/viewModels/QoLViewModel.ts
+++ b/mobile/src/viewModels/QoLViewModel.ts
@@ -6,7 +6,7 @@ import { ILocalSettingsController } from 'src/controllers/LocalSettings';
 import { PartialQol, QolSurveyResults, QolSurveyResultsHelper, QolSurveyKeys, QolSurveyType } from 'src/constants/QoL';
 import { PersonaArmState } from 'dependencies/persona/lib';
 import { sum } from 'src/helpers/DomainHelper';
-
+import Timer from 'tiny-timer'
 export const logger = createLogger('[QOLModel]');
 
 export default class QOLSurveyViewModel {
@@ -29,6 +29,7 @@ export default class QOLSurveyViewModel {
     private readonly _settings: ILocalSettingsController = AppController.Instance.User.localSettings;
 
     constructor() {
+        this.timer.on('tick', () => this.timerFired(this))
         this.initModel = AppController.Instance.User.qol.getPartialQol().then((partialQolState: PartialQol) => {
             if (partialQolState !== null && typeof (partialQolState) !== 'undefined') {
                 this._questionNum = partialQolState.questionNum;
@@ -91,8 +92,10 @@ export default class QOLSurveyViewModel {
     }
 
     get surveyResponses(): any { return this._surveyResponses; }
+    private sent: any = null;
 
     get qolArmMagnitudes(): any { return this._armMagnitudes; }
+    set qolArmMagnitudes(newValue: any) { this._armMagnitudes = newValue; }
 
     set setQolSurveyType(type: QolSurveyType) { this.qolSurveyType = type; }
 
@@ -112,31 +115,50 @@ export default class QOLSurveyViewModel {
         }
     }
 
-    public savePrevResponse(prevResponse: number): void {
-        const currDomain: string = this.domain;
-        console.log('currDomain', currDomain)
-        console.log('_surveyResponses', this._surveyResponses)
-        this._surveyResponses[currDomain][this.questionNum % DOMAIN_QUESTION_COUNT] = prevResponse;
-        this.saveSurveyProgress(this.qolArmMagnitudes);
+    private timer = null;
+
+    private timerFired(self: any) {
+        const responses = this.surveyResponses;
+        if (responses !== self.sent) {
+            console.log("SAVING")
+            self.sent = responses;
+            self.saveSurveyProgress().then(() => {
+                console.log("DONE")
+            });
+        }
     }
 
-    public saveSurveyProgress = async (qolArmMagnitudes: PersonaArmState) => {
-        this._armMagnitudes = qolArmMagnitudes;
+    public async savePrevResponse(prevResponse: number) {
+        const currDomain: string = this.domain;
+        this._surveyResponses[currDomain][this.questionNum % DOMAIN_QUESTION_COUNT] = prevResponse;
+        const now = new Date().getTime();
+        this.questionCompletionDates = this.questionCompletionDates || [];
+        if (this.questionCompletionDates.length > this.questionNum) {
+            this.questionCompletionDates[this.questionNum] = now;
+        } else {
+            this.questionCompletionDates.push(now);
+        }
+        this.sent = null;
+
+        if (this.questionNum === (this.numQuestions - 1)) {
+            this.timer.stop();
+            this.timer = null;
+            await this.saveSurveyProgress();
+        } else if (this.timer == null || this.timer.status != 'running') {
+            this.timer = new Timer({ interval: 5000 });
+            this.timer.start(60000 * 1000); // max out at 1000 min
+        }
+    }
+
+    // Update the user's userState with the current (partial) qol survey progress 
+    public saveSurveyProgress = async (reset: boolean = false) => {
         let res: boolean;
-        if (qolArmMagnitudes === null) {
+        if (reset) {
             res = await AppController.Instance.User.qol.sendPartialQol(null);
             this.isUnfinished = false;
         } else {
-            const now = new Date().getTime();
-            this.questionCompletionDates = this.questionCompletionDates || [];
-            if (this.questionCompletionDates.length - 1 >= this.questionNum) {
-                this.questionCompletionDates[this.questionNum] = now;
-            } else {
-                this.questionCompletionDates.push(now);
-            }
-
             let partialQol: PartialQol = {
-                questionNum: this._questionNum + 1, // + 1 is required as this method is called before nextQuestion() which increments the questionNum counter
+                questionNum: this._questionNum, //+ 1, // + 1 is required as this method is called before nextQuestion() which increments the questionNum counter
                 domainNum: this._domainNum,
                 scores: this._surveyResponses,
                 startDate: this.startDate,
@@ -149,25 +171,19 @@ export default class QOLSurveyViewModel {
         return res;
     }
 
+    // Calculate the user's aggregateScore and save the survey to firestore/surveyResults
     public sendSurveyResults = async () => {
         let aggregateScore = 0;
-        const entries = Object.entries(this._surveyResponses)
-        for (const [key, value] of entries) {
-            aggregateScore += sum(value);
+        const keys = Object.keys(QolSurveyKeys) //(this._surveyResponses)
+        for (const surveyKey of keys) {
+            aggregateScore += sum(this._surveyResponses[surveyKey]);
         }
-        aggregateScore /= entries.length
+        aggregateScore /= keys.length;
         const res: boolean = await AppController.Instance.User.qol.sendSurveyResults(this._surveyResponses, aggregateScore, this.qolSurveyType, this.startDate, this.questionCompletionDates);
         return res;
     }
 
-    public completeQolOnboarding() {
-        this._settings.updateOnboardingSettings({ needsQolOnboarding: false }, 'needsQolOnboarding')
-        this._settings.updateQolSettings({ lastFullQol: Date() }, 'lastFullQol');
-        this._settings.updateQolSettings({ isFirstEverQol: false }, 'isFirstEverQol');
-        this.showInterlude = false;
-    }
-
-    public updatePendingQol() {
+    public resolvePendingQol() {
         switch (this.qolSurveyType) {
             case QolSurveyType.Full:
                 this._settings.updateQolSettings({ pendingFullQol: false }, 'pendingFullQol');
@@ -194,6 +210,13 @@ export default class QOLSurveyViewModel {
             currentArmMagnitudes[domain] = mag;
         }
         return currentArmMagnitudes;
+    }
+
+    public completeQolOnboarding() {
+        this._settings.updateOnboardingSettings({ needsQolOnboarding: false }, 'needsQolOnboarding')
+        this._settings.updateQolSettings({ lastFullQol: Date() }, 'lastFullQol');
+        this._settings.updateQolSettings({ isFirstEverQol: false }, 'isFirstEverQol');
+        this.showInterlude = false;
     }
 
 }

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -7660,6 +7660,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+mitt@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.1.0.tgz#f740577c23176c6205b121b2973514eade1b2230"
+  integrity sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -9650,6 +9655,13 @@ through2@^2.0.1:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+tiny-timer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/tiny-timer/-/tiny-timer-1.6.0.tgz#bae5a112da9f0246b5a8676c86160718680aae68"
+  integrity sha512-2ciJ4w+0EKDRmVihzj8aBxDw2da9L88aTwslhf1Clphwt2NV927N7xH90tqz/M02lziboDkx+IypnnWqzjnv9g==
+  dependencies:
+    mitt "^2.1.0"
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Changes
adds `tiny-timer`
Submits the partial state of the Qol survey every 5 seconds instead of after each question. 

## Requirements

Requires: `yarn install` in /mobile

## Testing
Reset your user before going through the onboarding and completing the qol survey, check firebase as you go to confirm your survey is being saved every 5 seconds. 

- [x] Manual 